### PR TITLE
New v0.1.1 features

### DIFF
--- a/chrononaut/__init__.py
+++ b/chrononaut/__init__.py
@@ -139,11 +139,11 @@ class Versioned(object):
     """
     @declared_attr
     def __mapper_cls__(cls):
-        def map(cls, *arg, **kw):
+        def map_function(cls, *arg, **kw):
             mp = mapper(cls, *arg, **kw)
             history_mapper(mp)
             return mp
-        return map
+        return map_function
 
     def versions(self, before=None, after=None, return_query=False):
         """Fetch the history of the given object from its history table.
@@ -309,8 +309,8 @@ class Versioned(object):
         return None
 
 
-def versioned_objects(iter):
-    for obj in iter:
+def versioned_objects(items):
+    for obj in items:
         if hasattr(obj, '__history_mapper__'):
             yield obj
 

--- a/chrononaut/__init__.py
+++ b/chrononaut/__init__.py
@@ -295,11 +295,18 @@ class Versioned(object):
 
     def _get_custom_change_info(self):
         """Optionally return additional ``change_info`` fields to be
-        inserted into the history record.
+        inserted into the history record. By default, this checks for a Flask app
+        config variable `CHRONONAUT_EXTRA_CHANGE_INFO_FUNC` and calls the callable
+        stored there (note that this may need to be wrapped with `staticfunction`).
+        If not defined, returns no additional change info. Note that :class:`Versioned`
+        may be subclassed to further refine how custom change info is generated and propagated.
 
         :return: A dictionary of additional ``change_info`` keys and values
         """
-        pass
+        extra_info = self._sa_instance_state.session.app.config.get('CHRONONAUT_EXTRA_CHANGE_INFO_FUNC')
+        if extra_info:
+            return extra_info()
+        return None
 
 
 def versioned_objects(iter):

--- a/chrononaut/__init__.py
+++ b/chrononaut/__init__.py
@@ -7,7 +7,6 @@
     :copyright: (c) 2017 by Reference Genomics, Inc.
     :license: MIT, see LICENSE for more details.
 """
-from contextlib import contextmanager
 
 import sqlalchemy
 from sqlalchemy.ext.declarative import declared_attr
@@ -20,76 +19,14 @@ from sqlalchemy import event
 from flask_sqlalchemy import SignallingSession, SQLAlchemy
 
 # For our specific change_info logging
-from flask import g, request
+from flask import request
 from flask.globals import _app_ctx_stack, _request_ctx_stack
 
 # Chrononaut imports
 from chrononaut.exceptions import ChrononautException
+from chrononaut.context_managers import append_change_info, extra_change_info
 from chrononaut.history_mapper import history_mapper
 from chrononaut.flask_versioning import create_version
-
-
-@contextmanager
-def extra_change_info(**kwargs):
-    """A context manager for appending extra ``change_info`` into Chrononaut
-    history records for :class:`Versioned` models. Supports appending
-    changes to multiple individual objects of the same or varied classes.
-
-    Usage::
-
-        with extra_change_info(change_rationale='User request'):
-            user.email = 'new-email@example.com'
-            letter.subject = 'Welcome New User!'
-            db.session.commit()
-
-    Note that the ``db.session.commit()`` change needs to occur within the context manager block
-    for additional fields to get injected into the history table ``change_info`` JSON within
-    an ``extra`` info field. Any number of keyword arguments with string values are supported.
-
-    The above example yields a ``change_info`` like the following::
-
-        {
-            "user_id": "admin@example.com",
-            "remote_addr": "127.0.0.1",
-            "extra": {
-                "change_rationale": "User request"
-            }
-        }
-    """
-    if _app_ctx_stack.top is None:
-        raise ChrononautException('Can only use `extra_change_info` in a Flask app context.')
-    setattr(g, '__version_extra_change_info__', kwargs)
-    yield
-    delattr(g, '__version_extra_change_info__')
-
-
-@contextmanager
-def append_change_info(obj, **kwargs):
-    """A context manager for appending extra ``change`` info
-    directly onto a single model instance. Use :func:`extra_change_info`
-    for tracking multiple objects of the same or different classes.
-
-    Usage::
-
-        with append_change_info(user, change_rationale='User request'):
-            user.email = 'new-email@example.com'
-            db.session.commit()
-
-    Note that ``db.session.commit()`` does *not* need to occur within the context manager
-    block for additional fields to be appended. Changes take the same form as with
-    :func:`extra_change_info`.
-    """
-    if _app_ctx_stack.top is None:
-        raise ChrononautException('Can only use `append_change_info` in a Flask app context.')
-
-    if not hasattr(obj, 'versions'):
-        raise ChrononautException('Cannot append_change_info to an object that is not Versioned.')
-
-    obj.__CHRONONAUT_RECORDED_CHANGES__ = {}
-    for key, val in kwargs.items():
-        obj.__CHRONONAUT_RECORDED_CHANGES__[key] = val
-
-    yield
 
 
 def _in_flask_context():

--- a/chrononaut/context_managers.py
+++ b/chrononaut/context_managers.py
@@ -1,0 +1,67 @@
+from contextlib import contextmanager
+
+from flask import g, _app_ctx_stack
+from chrononaut.exceptions import ChrononautException
+
+
+@contextmanager
+def extra_change_info(**kwargs):
+    """A context manager for appending extra ``change_info`` into Chrononaut
+    history records for :class:`Versioned` models. Supports appending
+    changes to multiple individual objects of the same or varied classes.
+
+    Usage::
+
+        with extra_change_info(change_rationale='User request'):
+            user.email = 'new-email@example.com'
+            letter.subject = 'Welcome New User!'
+            db.session.commit()
+
+    Note that the ``db.session.commit()`` change needs to occur within the context manager block
+    for additional fields to get injected into the history table ``change_info`` JSON within
+    an ``extra`` info field. Any number of keyword arguments with string values are supported.
+
+    The above example yields a ``change_info`` like the following::
+
+        {
+            "user_id": "admin@example.com",
+            "remote_addr": "127.0.0.1",
+            "extra": {
+                "change_rationale": "User request"
+            }
+        }
+    """
+    if _app_ctx_stack.top is None:
+        raise ChrononautException('Can only use `extra_change_info` in a Flask app context.')
+    setattr(g, '__version_extra_change_info__', kwargs)
+    yield
+    delattr(g, '__version_extra_change_info__')
+
+
+@contextmanager
+def append_change_info(obj, **kwargs):
+    """A context manager for appending extra ``change`` info
+    directly onto a single model instance. Use :func:`extra_change_info`
+    for tracking multiple objects of the same or different classes.
+
+    Usage::
+
+        with append_change_info(user, change_rationale='User request'):
+            user.email = 'new-email@example.com'
+            db.session.commit()
+
+    Note that ``db.session.commit()`` does *not* need to occur within the context manager
+    block for additional fields to be appended. Changes take the same form as with
+    :func:`extra_change_info`.
+    """
+    if _app_ctx_stack.top is None:
+        raise ChrononautException('Can only use `append_change_info` in a Flask app context.')
+
+    if not hasattr(obj, 'versions'):
+        raise ChrononautException('Cannot append_change_info to an object that is not Versioned.')
+
+    obj.__CHRONONAUT_RECORDED_CHANGES__ = {}
+    for key, val in kwargs.items():
+        obj.__CHRONONAUT_RECORDED_CHANGES__[key] = val
+
+    yield

--- a/chrononaut/flask_versioning.py
+++ b/chrononaut/flask_versioning.py
@@ -10,10 +10,13 @@ from sqlalchemy.orm.properties import RelationshipProperty
 from chrononaut.exceptions import ChrononautException
 
 
-def fetch_recorded_changes():
+def fetch_recorded_changes(obj):
     if _app_ctx_stack.top is None:
         return None
-    return getattr(g, '__version_extra_change_info__', None)
+    changes = getattr(g, '__version_extra_change_info__', {})
+    object_changes = getattr(obj, '__CHRONONAUT_RECORDED_CHANGES__', {})
+    changes.update(object_changes)
+    return changes
 
 
 def create_version(obj, session, deleted=False):
@@ -98,8 +101,8 @@ def create_version(obj, session, deleted=False):
     attr['version'] = obj.version or 0
     change_info = obj._capture_change_info()
 
-    recorded_changes = fetch_recorded_changes()
-    if recorded_changes is not None:
+    recorded_changes = fetch_recorded_changes(obj)
+    if recorded_changes:
         change_info['extra'] = {}
         for key, val in recorded_changes.items():
             change_info['extra'][key] = val

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -19,3 +19,5 @@ Helper functions
 ----------------
 
 .. autofunction:: extra_change_info
+
+.. autofunction:: append_change_info

--- a/push_to_pypi.sh
+++ b/push_to_pypi.sh
@@ -1,3 +1,5 @@
+#!/usr/local/bin/bash
+
 set -e
 
 source venv/bin/activate

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ test=pytest
 [tool:pytest]
 addopts = --verbose
 python_files = chrononaut/tests/*.py
+
+[pep8]
+max-line-length = 160

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,13 @@ def strict_session(app, request):
     app.config['CHRONONAUT_REQUIRE_EXTRA_CHANGE_INFO'] = False
 
 
+@pytest.yield_fixture(scope='function')
+def extra_change_info(app, request):
+    app.config['CHRONONAUT_EXTRA_CHANGE_INFO_FUNC'] = lambda: {'extra_field': True}
+    yield
+    app.config['CHRONONAUT_EXTRA_CHANGE_INFO_FUNC'] = None
+
+
 def generate_test_models(db):
     # A few classes for testing versioning
     class UnversionedTodo(db.Model):

--- a/tests/test_change_info.py
+++ b/tests/test_change_info.py
@@ -34,3 +34,15 @@ def test_change_info(db, session, logged_in_user):
     prior_todo = todo.versions()[0]
     assert prior_todo.change_info['user_id'] == 'test@example.com'
     assert prior_todo.change_info['remote_addr'] == '127.0.0.1'
+    assert 'extra_field' not in prior_todo.change_info
+
+
+def test_custom_change_info(db, session, extra_change_info):
+    todo = db.Todo('First Todo', 'Check change info')
+    session.add(todo)
+    session.commit()
+    todo.title = 'Modified'
+    session.commit()
+
+    prior_todo = todo.versions()[0]
+    assert prior_todo.change_info['extra_field'] is True

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from chrononaut import extra_change_info
+from chrononaut import append_change_info, extra_change_info
 import chrononaut
 
 import pytest
@@ -24,6 +24,20 @@ def test_extra_change_info(db, session):
     session.commit()
 
     assert 'extra' not in todo.versions()[1].change_info.keys()
+
+
+def test_append_change_info(db, session):
+    todo = db.Todo('Task 0', 'Append direct')
+    session.add(todo)
+    session.commit()
+
+    with append_change_info(todo, reason='Extra object info'):
+        todo.title = 'Task -1'
+
+    # Commit does *not* need to be in the block
+    session.commit()
+
+    assert todo.versions()[0].change_info['extra']['reason'] == 'Extra object info'
 
 
 def test_unstrict_session(db, session):


### PR DESCRIPTION
This PR adds:
- An `append_change_info` context manager (for legacy backwards compatibility, as well as the ability to mark changes for a single object rather than within a context/commit block)
- The ability to set custom change info recording via a function specified in the Flask config `CHRONONAUT_EXTRA_CHANGE_INFO_FUNC` variable – this removes the need to subclass `Versioned` for simply adding extra change information. Note the interface for this feature is likely unstable and may be broken as soon as `v0.2.0`.
- Some general code cleanup and renaming