### PR TITLE
Check for key collisions on insert, based on user flag

### DIFF
--- a/chrononaut/__init__.py
+++ b/chrononaut/__init__.py
@@ -16,7 +16,7 @@ from flask_sqlalchemy import SignallingSession, SQLAlchemy
 
 
 # Chrononaut imports
-from chrononaut.change_info import append_recorded_changes, RecordChanges
+from chrononaut.change_info import append_recorded_changes, RecordChanges, increment_version_on_insert
 from chrononaut.context_managers import append_change_info, extra_change_info, rationale
 from chrononaut.exceptions import ChrononautException
 from chrononaut.flask_versioning import create_version
@@ -37,6 +37,8 @@ def versioned_session(session):
         for obj in session.new:
             if hasattr(obj, '__chrononaut_record_change_info__'):
                 append_recorded_changes(obj, session)
+            if hasattr(obj, '__chrononaut_primary_key_nonunique__'):
+                increment_version_on_insert(obj)
 
         for obj in session.dirty:
             if hasattr(obj, '__history_mapper__'):

--- a/chrononaut/change_info.py
+++ b/chrononaut/change_info.py
@@ -102,3 +102,14 @@ def append_recorded_changes(obj, session):
 
     obj.change_info = fetch_change_info(obj)
     obj.changed = datetime.now(pytz.utc)
+
+
+def increment_version_on_insert(obj):
+    """Increments the version of the object to +1 after the last version in history. This will only
+    ever be called when inserting a row into the table, and is only necessary when there may be
+    primary key collisions on the main table in columns other than `version`.
+    """
+    history_model = obj.previous_version()
+
+    if history_model is not None:
+        obj.version = history_model.version + 1

--- a/chrononaut/versioned.py
+++ b/chrononaut/versioned.py
@@ -111,6 +111,17 @@ class Versioned(ChangeInfoMixin):
         """
         return self.version_at(at=since) is not self
 
+    def previous_version(self):
+        """Fetch the previous version of this model (or None)
+
+        :return: A history model, or ``None`` if no history exists
+        """
+        query = self.versions(return_query=True)
+
+        # order_by(None) resets order_by() called in versions()
+        query = query.order_by(None).order_by(self.__history_mapper__.class_.version.desc())
+        return query.first()
+
     def diff(self, from_model, to=None, include_hidden=False):
         """Enumerate the changes from a prior history model to a later history model or the current model's
         state (if ``to`` is ``None``).


### PR DESCRIPTION
This PR addresses #7, where primary keys other than auto-incrementing integers can cause collisions on insert into chrononaut history tables.

- Introduced a new mixin, `VersionUnusualPrimaryKey`. This mixin is intended to be used alongside `Versioned` in the SQLAlchemy table model definition, where it adds a flag, `__chrononaut_unusual_primary_key__`.
- Flag only affects insert operations, where primary key collisions in the history table might occur.
- Before insert (and if flagged), chrononaut finds the most recent `version` number in the history table with the same primary key, and increments it by one, thus avoiding a primary key collision.
- Add a `previous_version()` method that returns the most recent history model or `None` if there's no history. This avoids having to call `versions()` which pulls all the history models.