### PR TITLE
Reinstate old diff API, add new methods as supplements

### DIFF
--- a/tests/test_change_info.py
+++ b/tests/test_change_info.py
@@ -3,13 +3,18 @@ from chrononaut import extra_change_info
 from chrononaut.flask_versioning import UTC
 
 
-def test_change_info_no_user(db, session):
+def _prepare_todo(db, init_title, init_text, new_title):
+    todo = db.Todo(init_title, init_text)
+    db.session.add(todo)
+    db.session.commit()
+    todo.title = new_title
+    db.session.commit()
+    return todo
+
+
+def test_change_info_no_user(db):
     """Test that change info is as expected without a user"""
-    todo = db.Todo("First Todo", "Check change info")
-    session.add(todo)
-    session.commit()
-    todo.title = "Modified"
-    session.commit()
+    todo = _prepare_todo(db, "First Todo", "Check change info", "Modified")
 
     assert len(todo.versions()) == 2
     assert todo.version == 1
@@ -19,23 +24,14 @@ def test_change_info_no_user(db, session):
     assert prior_todo.chrononaut_meta["user_info"]["user_id"] is None
 
 
-def test_change_info_anonymous_user(db, session, anonymous_user):
-    todo = db.Todo("Anonymous Todo", "Expect no user id")
-    session.add(todo)
-    session.commit()
-    todo.title = "Modified"
-    session.commit()
+def test_change_info_anonymous_user(db, anonymous_user):
+    todo = _prepare_todo(db, "Anonymous Todo", "Expect no user id", "Modified")
     assert todo.versions()[1].chrononaut_meta["user_info"]["user_id"] is None
 
 
-def test_change_info(db, session, logged_in_user):
+def test_change_info(db, logged_in_user):
     """Test that change info is as expected with a user"""
-    todo = db.Todo("First Todo", "Check change info")
-    session.add(todo)
-    session.commit()
-    todo.title = "Modified"
-    session.commit()
-
+    todo = _prepare_todo(db, "First Todo", "Check change info", "Modified")
     assert len(todo.versions()) == 2
     prior_todo = todo.versions()[1]
     assert prior_todo.chrononaut_meta["user_info"]["user_id"] == "test@example.com"
@@ -43,24 +39,19 @@ def test_change_info(db, session, logged_in_user):
     assert not prior_todo.chrononaut_meta["extra_info"]
 
 
-def test_custom_change_info(db, session, extra_change_info):
-    todo = db.Todo("First Todo", "Check change info")
-    session.add(todo)
-    session.commit()
-    todo.title = "Modified"
-    session.commit()
-
+def test_custom_change_info(db, extra_change_info):
+    todo = _prepare_todo(db, "First Todo", "Check change info", "Modified")
     assert len(todo.versions()) == 2
     prior_todo = todo.versions()[1]
     assert "extra_field" in prior_todo.chrononaut_meta["extra_info"]
     assert prior_todo.chrononaut_meta["extra_info"]["extra_field"] is True
 
 
-def test_change_info_mixin(db, session, logged_in_user):
+def test_change_info_mixin(db, logged_in_user):
     note = db.ChangeLog(note="Creating a new change note...")
     with extra_change_info(comment="Adding a note from test function"):
-        session.add(note)
-        session.commit()
+        db.session.add(note)
+        db.session.commit()
     assert note.change_info["user_id"] == "test@example.com"
     assert note.change_info["remote_addr"] == "10.0.0.1"
     assert (datetime.now(UTC) - note.changed).total_seconds() < 1
@@ -69,7 +60,7 @@ def test_change_info_mixin(db, session, logged_in_user):
 
     # Now make a change
     note.note = "Updating our note"
-    session.commit()
+    db.session.commit()
 
     # Also check that versions query works
     now = datetime.now(UTC)

--- a/tests/test_data_converters.py
+++ b/tests/test_data_converters.py
@@ -42,7 +42,7 @@ def test_convert_model_polymorphic(db, session):
     todo.title = "New title #1"
     db.session.commit()
 
-    assert todo.diff(time_0)["title"] == ("Special Todo #1", "New title #1")
+    assert todo.diff_timestamps(time_0)["title"] == ("Special Todo #1", "New title #1")
 
 
 def test_convert_model_no_inheritance(db, session):


### PR DESCRIPTION
The `diff` method signature has changed since the old chrononaut version.
In order to avoid user confusion, reinstating the old signature for the default `diff` method and adding the new ones as supplementary options.