### PR TITLE
pin flask-WTF and fix test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ python-dateutil
 pytest>=3.0.7
 pytest-cov==2.4.0
 Flask-Security-Fork==2.0.1
+Flask-WTF==1.0.1
 Werkzeug==2.0.0
 sphinx==1.5.5
 sphinx-autobuild==0.6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from chrononaut.flask_versioning import serialize_datetime, UTC
+from chrononaut.flask_versioning import UTC
 from datetime import datetime
 import os
 from enum import Enum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from chrononaut.flask_versioning import serialize_datetime, UTC
 from datetime import datetime
 import os
 from enum import Enum
@@ -87,7 +88,7 @@ def generate_test_models(db):
             self.title = title
             self.text = text
             self.done = False
-            self.pub_date = datetime.utcnow()
+            self.pub_date = datetime.now(UTC)
 
     class Priority(Enum):
         LOW = "low"
@@ -126,7 +127,7 @@ def generate_test_models(db):
             self.text = text
             self.done = False
             self.starred = False
-            self.pub_date = datetime.utcnow()
+            self.pub_date = datetime.now(UTC)
             if preset_id:
                 self.id = preset_id
 


### PR DESCRIPTION
• Pin Flask-WTF at `1.0.1` to fix compatibility issue leading to "LoginForm.validate got unexpected keyword extra_validators" error in test
• Standardize datetime / UTC usage in test to fix failure