### PR TITLE
Use empty set for default value of hidden

### DIFF
--- a/chrononaut/models.py
+++ b/chrononaut/models.py
@@ -39,7 +39,7 @@ class HistorySnapshot(object):
             "extra_info": activity_obj.extra_info,
         }
         self._untracked = untracked if untracked else []
-        self._hidden = set(hidden) if hidden else {}
+        self._hidden = set(hidden) if hidden else set()
         self._activity_obj = activity_obj
         self.__initialized__ = True
 


### PR DESCRIPTION
`v0.diff(v1)` is throwing the following exception in `chrononaut==0.4.0`:

```
File /usr/local/lib/python3.10/site-packages/chrononaut/models.py:64, in HistorySnapshot.diff(self, other_history_model)
     62 all_keys = set(from_dict.keys())
     63 all_keys.update(to_dict.keys())
---> 64 all_keys = all_keys.difference(hidden_cols.union({"version"}))
     66 diff = {}
     67 for k in all_keys:

AttributeError: 'dict' object has no attribute 'union'
```

I think the default value of `_hidden` should be `set()` not `{}`.