### PR TITLE
Compare based on `changed` instead of `version`

### DIFF
--- a/chrononaut/models.py
+++ b/chrononaut/models.py
@@ -52,7 +52,7 @@ class HistorySnapshot(object):
                 for k in self._data.keys()
                 if k not in hidden_cols and k != "version"
             }
-        elif self._version == other_history_model._version:
+        elif self.chrononaut_meta["changed"] == other_history_model.chrononaut_meta["changed"]:
             # Exit early if we are comparing the same version
             return {}
         else:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ adding support for audit logging, record locking, and time travel!
 from setuptools import setup, find_packages
 import sys
 
-__version__ = "0.4.0"
+__version__ = "0.4.2"
 
 
 if sys.version_info[0] < 3:


### PR DESCRIPTION
Since the `version` attribute is subject to being duplicated upon multiple connections flushing at the same time, version comparison should be based on a trustworthy `changed` attribute.
This PR does exactly that.