### PR TITLE
Drop psycopg dependency

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,11 +9,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: set PY
       run: echo "PY=$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')" >> $GITHUB_ENV
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,15 +24,15 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Cache virtualenv
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-pip
         with:
           path: venv

--- a/chrononaut/__init__.py
+++ b/chrononaut/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    chrononaut
-    ~~~~~~~~~~~~~~~~~~~
-    A history mixin for audit logging, record locking, and time travel with Flask-SQLAlchemy
-    :copyright: (c) 2017 by Reference Genomics, Inc.
-    :license: MIT, see LICENSE for more details.
+chrononaut
+~~~~~~~~~~~~~~~~~~~
+A history mixin for audit logging, record locking, and time travel with Flask-SQLAlchemy
+:copyright: (c) 2017 by Reference Genomics, Inc.
+:license: MIT, see LICENSE for more details.
 """
 
 from sqlalchemy import event

--- a/chrononaut/change_info.py
+++ b/chrononaut/change_info.py
@@ -1,5 +1,5 @@
-"""Change info mixins. Require Flask for getting request and app context variables.
-"""
+"""Change info mixins. Require Flask for getting request and app context variables."""
+
 from datetime import datetime
 
 from flask import current_app, g, request, has_request_context, has_app_context

--- a/chrononaut/exceptions.py
+++ b/chrononaut/exceptions.py
@@ -1,5 +1,4 @@
-"""Custom Exceptions raised by History Models
-"""
+"""Custom Exceptions raised by History Models"""
 
 
 class ChrononautException(Exception):

--- a/chrononaut/flask_versioning.py
+++ b/chrononaut/flask_versioning.py
@@ -1,5 +1,8 @@
-"""Flask versioning extension. Requires g and _app_ctx_stack in looking for extra recorded changes.
 """
+Flask versioning extension.
+Requires g and _app_ctx_stack in looking for extra recorded changes.
+"""
+
 from flask import g, current_app, has_app_context
 from datetime import datetime
 from dateutil.tz import tzutc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 Flask>=2.3.2
 Flask-SQLAlchemy>=3.0.5
 SQLAlchemy==1.4.50
-psycopg2-binary>=2.8.1
 alembic>=1.5.1
 six>=1.15.0
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ enum34>=1.1.10
 flake8
 black==23.7.0
 sqlalchemy-utils
+psycopg2-binary
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Flask>=2.1.0",
         "Flask-SQLAlchemy>=2.5.1",
         "SQLAlchemy>=1.4.0",
-        "psycopg2>=2.7.1",
     ],
     extras_require={"user_info": ["Flask-Login>=0.4.0"]},
     include_package_data=True,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,5 @@
-"""Test basic FlaskSQLAlchemy integration points
-"""
+"""Test basic FlaskSQLAlchemy integration points"""
+
 import sqlalchemy
 
 import chrononaut


### PR DESCRIPTION
This PR drops the `psycopg2` dependency.
Even though we rely on postgres being the underlying database, users should be able to decide which driver they want to use on their own.